### PR TITLE
feat: Enhance API for PCAP analysis results

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,149 @@
+from fastapi import FastAPI, File, UploadFile, HTTPException
+import shutil
+import os
+import uuid # For unique IDs
+from starlette.responses import FileResponse
+from main import perform_pcap_analysis # Import the analysis function
+from config.settings import (
+    SURICATA_OUTPUT_DIR_NAME,
+    ZEEK_OUTPUT_DIR_NAME,
+    THREAT_INTEL_FILENAME,
+    ANOMALIES_FILENAME,
+)
+
+app = FastAPI(title="PCAP Analysis API", version="0.1.0")
+
+# Create uploads directory if it doesn't exist
+UPLOADS_DIR = "uploads"
+os.makedirs(UPLOADS_DIR, exist_ok=True)
+
+ANALYSIS_RESULTS_DIR = "analysis_results"
+os.makedirs(ANALYSIS_RESULTS_DIR, exist_ok=True)
+
+# Allowed log file names
+ALLOWED_SURICATA_LOGS = ["eve.json", "fast.log", "stats.log", "suricata.log"]
+ALLOWED_ZEEK_LOGS = [
+    "conn.log", "dns.log", "files.log", "http.log", "packet_filter.log",
+    "smtp.log", "ssl.log", "weird.log", "x509.log"
+]
+
+
+@app.get("/")
+async def root():
+    return {"message": "Welcome to the PCAP Analysis API"}
+
+@app.post("/api/upload_pcap")
+async def upload_pcap(file: UploadFile = File(...)):
+    # Generate a unique ID for this analysis session
+    analysis_id = str(uuid.uuid4())
+
+    # Create a specific directory for this uploaded PCAP's results
+    pcap_upload_path = os.path.join(UPLOADS_DIR, analysis_id) # This is where the original PCAP is saved
+    os.makedirs(pcap_upload_path, exist_ok=True)
+
+    file_path = os.path.join(pcap_upload_path, file.filename)
+
+    try:
+        with open(file_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+    finally:
+        file.file.close()
+
+    # Trigger analysis
+    # This is a synchronous call. For long analyses, consider background tasks.
+    # The perform_pcap_analysis function is expected to save results in ANALYSIS_RESULTS_DIR/analysis_id
+    report_path, _ = perform_pcap_analysis(file_path, analysis_id)
+
+    return {
+        "message": f"PCAP file '{file.filename}' uploaded and analysis started.",
+        "analysis_id": analysis_id,
+        "saved_pcap_path": file_path, # Original pcap path
+        "report_path": report_path, # Path to the markdown report
+        "filename": file.filename
+    }
+
+@app.get("/api/analyses", summary="List all available analysis IDs")
+async def list_analyses():
+    """
+    Retrieves a list of all analysis IDs for which results are available.
+    Each ID corresponds to a previously uploaded and processed PCAP file.
+    """
+    if not os.path.exists(ANALYSIS_RESULTS_DIR) or not os.path.isdir(ANALYSIS_RESULTS_DIR):
+        return []
+    try:
+        analysis_ids = [
+            d for d in os.listdir(ANALYSIS_RESULTS_DIR)
+            if os.path.isdir(os.path.join(ANALYSIS_RESULTS_DIR, d))
+        ]
+        return analysis_ids
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error listing analyses: {str(e)}")
+
+@app.get("/api/analyses/{analysis_id}/report", summary="Get analysis report")
+async def get_analysis_report(analysis_id: str):
+    """
+    Retrieves the main analysis report in Markdown format for the given analysis ID.
+    """
+    report_path = os.path.join(ANALYSIS_RESULTS_DIR, analysis_id, "pcap_analysis_report.md")
+    if os.path.exists(report_path):
+        return FileResponse(report_path, media_type='text/markdown', filename="pcap_analysis_report.md")
+    else:
+        raise HTTPException(status_code=404, detail="Report not found.")
+
+@app.get("/api/analyses/{analysis_id}/suricata/{log_file}", summary="Get Suricata log file")
+async def get_suricata_log(analysis_id: str, log_file: str):
+    """
+    Retrieves a specific Suricata log file (e.g., eve.json, fast.log) for the given analysis ID.
+    Allowed log files are: eve.json, fast.log, stats.log, suricata.log.
+    """
+    if log_file not in ALLOWED_SURICATA_LOGS:
+        raise HTTPException(status_code=400, detail=f"Log file '{log_file}' is not allowed for Suricata.")
+
+    file_path = os.path.join(ANALYSIS_RESULTS_DIR, analysis_id, SURICATA_OUTPUT_DIR_NAME, log_file)
+    if os.path.exists(file_path):
+        return FileResponse(file_path, media_type='application/text', filename=log_file) # Adjust media type if specific (e.g. eve.json is application/json)
+    else:
+        raise HTTPException(status_code=404, detail=f"Suricata log file '{log_file}' not found.")
+
+@app.get("/api/analyses/{analysis_id}/zeek/{log_file}", summary="Get Zeek log file")
+async def get_zeek_log(analysis_id: str, log_file: str):
+    """
+    Retrieves a specific Zeek log file for the given analysis ID.
+    Allowed log files include: conn.log, dns.log, http.log, etc.
+    """
+    if log_file not in ALLOWED_ZEEK_LOGS:
+        raise HTTPException(status_code=400, detail=f"Log file '{log_file}' is not allowed for Zeek.")
+
+    file_path = os.path.join(ANALYSIS_RESULTS_DIR, analysis_id, ZEEK_OUTPUT_DIR_NAME, log_file)
+    if os.path.exists(file_path):
+        return FileResponse(file_path, media_type='application/text', filename=log_file) # Zeek logs are typically plain text
+    else:
+        raise HTTPException(status_code=404, detail=f"Zeek log file '{log_file}' not found.")
+
+@app.get("/api/analyses/{analysis_id}/threat_intel", summary="Get threat intelligence data")
+async def get_threat_intelligence(analysis_id: str):
+    """
+    Retrieves the threat intelligence data (raw and LLM analysis) in JSON format
+    for the given analysis ID.
+    """
+    file_path = os.path.join(ANALYSIS_RESULTS_DIR, analysis_id, THREAT_INTEL_FILENAME)
+    if os.path.exists(file_path):
+        return FileResponse(file_path, media_type="application/json", filename=THREAT_INTEL_FILENAME)
+    else:
+        raise HTTPException(status_code=404, detail="Threat intelligence report not found.")
+
+@app.get("/api/analyses/{analysis_id}/anomalies", summary="Get anomaly detection data")
+async def get_anomalies_report(analysis_id: str): # Renamed function to avoid conflict if I add a different get_anomalies_data
+    """
+    Retrieves the anomaly detection data (anomalies, summary, status) in JSON format
+    for the given analysis ID.
+    """
+    file_path = os.path.join(ANALYSIS_RESULTS_DIR, analysis_id, ANOMALIES_FILENAME)
+    if os.path.exists(file_path):
+        return FileResponse(file_path, media_type="application/json", filename=ANOMALIES_FILENAME)
+    else:
+        raise HTTPException(status_code=404, detail="Anomalies report not found.")
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/config/settings.py
+++ b/config/settings.py
@@ -3,3 +3,9 @@ USE_OLLAMA = False
 CHUTES_API_KEY = "cpk_b2f19b3b2443491a935341849094244e.0e4c136833ce5488ad2b68a2e843d103.jKtlSsaXnKa1CFQl7BR7UIXa5sfXud8A"
 CHUTES_API_BASE = "https://llm.chutes.ai/v1" 
 SURICATA_DOCS_URL = "https://suricata.readthedocs.io/en/latest/"
+
+# Names for output subdirectories within each analysis session
+SURICATA_OUTPUT_DIR_NAME = "suricata_output"
+ZEEK_OUTPUT_DIR_NAME = "zeek_output"
+THREAT_INTEL_FILENAME = "threat_intelligence.json"
+ANOMALIES_FILENAME = "anomalies.json"

--- a/modules/suricata_parser.py
+++ b/modules/suricata_parser.py
@@ -10,18 +10,21 @@ from config.settings import SURICATA_CONFIG, PCAP_FILE
 #cache = Cache("./cache_dir")
 
 #@cache.memoize()
-def run_suricata(pcap_path: str) -> list:
+def run_suricata(pcap_path: str, output_dir_base: str = None) -> list:
     """Run Suricata on PCAP file and parse results"""
-    output_dir = "suricata_output"
+    if output_dir_base:
+        output_dir = os.path.join(output_dir_base, "suricata_output")
+    else:
+        output_dir = "suricata_output"
     os.makedirs(output_dir, exist_ok=True)
     
     #SURICATA_CONFIG = "/opt/homebrew/etc/suricata/suricata.yaml" #Rules
-    OUTPUT_DIR = "suricata_output"
+    # OUTPUT_DIR = "suricata_output" # This line seems redundant
 
     try:
         subprocess.run([
             "suricata",
-            "-c", SURICATA_CONFIG,
+            "-c", SURICATA_CONFIG, # Ensure SURICATA_CONFIG is correctly defined in config.settings or globally
             "-r", pcap_path,
             "-l", output_dir
         ], check=True)
@@ -44,8 +47,9 @@ print ("✅ Suricata module loaded successfully")
 if __name__ == "__main__":
     # Replace with the path to a real PCAP file for testing
     test_pcap = PCAP_FILE
-    run_suricata(test_pcap)
-    print("Suricata analysis completed.")
-    #now print the events
+    # Example of running with a base directory
+    # run_suricata(test_pcap, output_dir_base="analysis_results/test_analysis_id")
+    # Original way for standalone testing:
     events = run_suricata(test_pcap)
+    print("Suricata analysis completed.")
     print("Suricata events:", events)

--- a/modules/zeek.py
+++ b/modules/zeek.py
@@ -6,15 +6,19 @@ from diskcache import Cache
 #cache = Cache("./cache_dir")
 
 #@cache.memoize()
-def run_zeek(pcap_path: str) -> dict:
+def run_zeek(pcap_path: str, output_dir_base: str = None) -> dict:
     """Run Zeek on PCAP file and parse logs"""
-    output_dir = "zeek_output"
+    if output_dir_base:
+        output_dir = os.path.join(output_dir_base, "zeek_output")
+    else:
+        output_dir = "zeek_output"
+
     output_path = Path(output_dir)
-    output_path.mkdir(exist_ok=True)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     try:
         result = subprocess.run(
-            ["zeek", "-C", "-r", pcap_path, f"Log::default_logdir={output_path.absolute()}"],
+            ["zeek", "-C", "-r", pcap_path, f"Log::default_logdir={str(output_path.absolute())}"],
             check=True,
             capture_output=True,
             text=True
@@ -37,6 +41,9 @@ def run_zeek(pcap_path: str) -> dict:
 #if __name__ == "__main__":
     # Replace with the path to a real PCAP file for testing
 #    test_pcap = "/Users/macbook/Desktop/CynsesAI/sample2.pcap"
+    # Example of running with a base directory
+    # logs = run_zeek(test_pcap, output_dir_base="analysis_results/test_analysis_id")
+    # Original way for standalone testing:
 #    logs = run_zeek(test_pcap)
 #    print("Zeek logs:", logs)
     #now print the logs
@@ -44,4 +51,4 @@ def run_zeek(pcap_path: str) -> dict:
 #        print(f"Log: {log_name}")
  #       for line in lines:
  #           print(line.strip())
- # #  print("✅ Zeek module loaded successfully")
+#  print("✅ Zeek module loaded successfully")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,255 @@
+import pytest
+import os
+import json
+import shutil
+from fastapi.testing import TestClient
+
+# Attempt to import the app and the api module itself for monkeypatching
+# This assumes api.py is in the parent directory or PYTHONPATH is set up correctly
+# For a typical project structure, if tests/ is a subdir of the project root,
+# and api.py is also in the project root, this might require path adjustments
+# or running pytest from the project root.
+try:
+    from api import app  # FastAPI app instance
+    import api as api_module # The module itself to patch its variables
+except ImportError:
+    # Adjust path if necessary for your project structure
+    import sys
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    from api import app
+    import api as api_module
+
+
+# Constants for test setup
+# Using a distinct name for test directory to avoid conflict if tests are interrupted.
+TEST_ANALYSIS_RESULTS_DIR = "test_analysis_results_temp"
+SAMPLE_ANALYSIS_ID = "test_analysis_123"
+
+# These should match what's in config.settings.py or how api.py defines them
+# If these are read from config.settings by api.py, the actual values from there will be used by the app
+# but for creating mock files, we define them here.
+SURICATA_OUTPUT_DIR_NAME = "suricata_output"
+ZEEK_OUTPUT_DIR_NAME = "zeek_output"
+THREAT_INTEL_FILENAME = "threat_intelligence.json"
+ANOMALIES_FILENAME = "anomalies.json"
+REPORT_FILENAME = "pcap_analysis_report.md" # As used in api.py for report
+
+# Dummy content
+DUMMY_REPORT_CONTENT = "# Test Report Content\nThis is a markdown report."
+DUMMY_EVE_JSON_CONTENT = {"event_type": "alert", "src_ip": "1.2.3.4"}
+DUMMY_FAST_LOG_CONTENT = "01/01/2024-10:00:00.000000  [**] [1:2000000:1] Test Alert [**]"
+DUMMY_CONN_LOG_CONTENT = "ts\tuid\tid.orig_h\tid.orig_p\tid.resp_h\tid.resp_p\tproto"
+DUMMY_THREAT_INTEL_CONTENT = {"ip_address": "1.2.3.4", "status": "malicious"}
+DUMMY_ANOMALIES_CONTENT = {"anomalies": [{"type": "weird_traffic", "score": 0.9}]}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def manage_test_analysis_dir(request):
+    """
+    Manages a temporary directory for analysis results during tests.
+    - Creates the directory and mock data before tests.
+    - Monkeypatches api_module.ANALYSIS_RESULTS_DIR to use this test directory.
+    - Cleans up the directory after tests.
+    """
+    original_analysis_dir = api_module.ANALYSIS_RESULTS_DIR
+    api_module.ANALYSIS_RESULTS_DIR = TEST_ANALYSIS_RESULTS_DIR
+
+    if os.path.exists(TEST_ANALYSIS_RESULTS_DIR):
+        shutil.rmtree(TEST_ANALYSIS_RESULTS_DIR)
+    os.makedirs(TEST_ANALYSIS_RESULTS_DIR, exist_ok=True)
+
+    # Create mock data for SAMPLE_ANALYSIS_ID
+    mock_analysis_path = os.path.join(TEST_ANALYSIS_RESULTS_DIR, SAMPLE_ANALYSIS_ID)
+    os.makedirs(mock_analysis_path, exist_ok=True)
+
+    # 1. pcap_analysis_report.md
+    with open(os.path.join(mock_analysis_path, REPORT_FILENAME), "w") as f:
+        f.write(DUMMY_REPORT_CONTENT)
+
+    # 2. Suricata output
+    suricata_dir = os.path.join(mock_analysis_path, SURICATA_OUTPUT_DIR_NAME)
+    os.makedirs(suricata_dir, exist_ok=True)
+    with open(os.path.join(suricata_dir, "eve.json"), "w") as f:
+        json.dump(DUMMY_EVE_JSON_CONTENT, f)
+    with open(os.path.join(suricata_dir, "fast.log"), "w") as f:
+        f.write(DUMMY_FAST_LOG_CONTENT)
+    # Create other allowed suricata files if needed for more specific tests
+    with open(os.path.join(suricata_dir, "stats.log"), "w") as f: f.write("dummy stats")
+    with open(os.path.join(suricata_dir, "suricata.log"), "w") as f: f.write("dummy suricata log")
+
+
+    # 3. Zeek output
+    zeek_dir = os.path.join(mock_analysis_path, ZEEK_OUTPUT_DIR_NAME)
+    os.makedirs(zeek_dir, exist_ok=True)
+    with open(os.path.join(zeek_dir, "conn.log"), "w") as f:
+        f.write(DUMMY_CONN_LOG_CONTENT)
+    # Create other allowed zeek files
+    for log_name in ["dns.log", "http.log", "files.log", "packet_filter.log", "smtp.log", "ssl.log", "weird.log", "x509.log"]:
+        with open(os.path.join(zeek_dir, log_name), "w") as f: f.write(f"dummy {log_name} content")
+
+
+    # 4. Threat intel
+    with open(os.path.join(mock_analysis_path, THREAT_INTEL_FILENAME), "w") as f:
+        json.dump(DUMMY_THREAT_INTEL_CONTENT, f)
+
+    # 5. Anomalies
+    with open(os.path.join(mock_analysis_path, ANOMALIES_FILENAME), "w") as f:
+        json.dump(DUMMY_ANOMALIES_CONTENT, f)
+
+    def cleanup():
+        shutil.rmtree(TEST_ANALYSIS_RESULTS_DIR)
+        api_module.ANALYSIS_RESULTS_DIR = original_analysis_dir # Restore
+
+    request.addfinalizer(cleanup)
+
+# Initialize TestClient
+client = TestClient(app)
+
+# --- Test Cases ---
+
+def test_list_analyses():
+    response = client.get("/api/analyses")
+    assert response.status_code == 200
+    assert SAMPLE_ANALYSIS_ID in response.json()
+
+def test_get_analysis_report():
+    response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/report")
+    assert response.status_code == 200
+    assert response.text == DUMMY_REPORT_CONTENT
+
+def test_get_analysis_report_not_found():
+    response = client.get("/api/analyses/non_existent_id/report")
+    assert response.status_code == 404
+
+# --- Suricata Log Tests ---
+def test_get_suricata_log_eve_json():
+    response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/suricata/eve.json")
+    assert response.status_code == 200
+    assert response.json() == DUMMY_EVE_JSON_CONTENT
+
+def test_get_suricata_log_fast_log():
+    response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/suricata/fast.log")
+    assert response.status_code == 200
+    assert response.text == DUMMY_FAST_LOG_CONTENT
+
+def test_get_suricata_log_disallowed_file():
+    # This file exists but is not in ALLOWED_SURICATA_LOGS by default in api.py
+    # It should be caught by the validation `if log_file not in ALLOWED_SURICATA_LOGS:`
+    response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/suricata/some_other_file.log")
+    assert response.status_code == 400 # Bad request due to disallowed file name
+
+def test_get_suricata_log_actually_not_found():
+    # This file is allowed but we didn't create it
+    # Example: ALLOWED_SURICATA_LOGS = ["eve.json", "fast.log", "stats.log", "suricata.log"]
+    # We created eve.json, fast.log, stats.log, suricata.log.
+    # Let's try to get one that doesn't exist physically.
+    # To make this test meaningful, we'd need an allowed log that we *don't* create.
+    # For now, let's assume 'alerts.log' is allowed but not created
+    # api_module.ALLOWED_SURICATA_LOGS.append("alerts.log") # Temporarily allow if not already
+    # response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/suricata/alerts.log")
+    # assert response.status_code == 404
+    # api_module.ALLOWED_SURICATA_LOGS.pop() # Clean up
+    # Simpler: try getting a file that is allowed but we didn't create.
+    # The fixture creates all allowed files, so this specific test is harder to set up
+    # without further modification of the fixture or ALLOWED_SURICATA_LOGS.
+    # Instead, we test the "analysis_id not found" case for suricata.
+    pass
+
+
+def test_get_suricata_log_analysis_id_not_found():
+    response = client.get("/api/analyses/non_existent_id/suricata/eve.json")
+    assert response.status_code == 404
+
+
+# --- Zeek Log Tests ---
+def test_get_zeek_log_conn_log():
+    response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/zeek/conn.log")
+    assert response.status_code == 200
+    assert response.text == DUMMY_CONN_LOG_CONTENT
+
+def test_get_zeek_log_disallowed_file():
+    response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/zeek/some_other_zeek.log")
+    assert response.status_code == 400 # Bad request
+
+def test_get_zeek_log_analysis_id_not_found():
+    response = client.get("/api/analyses/non_existent_id/zeek/conn.log")
+    assert response.status_code == 404
+
+# --- Threat Intel Tests ---
+def test_get_threat_intel():
+    response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/threat_intel")
+    assert response.status_code == 200
+    assert response.json() == DUMMY_THREAT_INTEL_CONTENT
+
+def test_get_threat_intel_not_found():
+    response = client.get("/api/analyses/non_existent_id/threat_intel")
+    assert response.status_code == 404
+
+# --- Anomalies Data Tests ---
+def test_get_anomalies_data(): # Corresponds to get_anomalies_report endpoint
+    response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/anomalies")
+    assert response.status_code == 200
+    assert response.json() == DUMMY_ANOMALIES_CONTENT
+
+def test_get_anomalies_data_not_found():
+    response = client.get("/api/analyses/non_existent_id/anomalies")
+    assert response.status_code == 404
+
+# --- Test specific file not founds within an existing analysis_id ---
+
+def test_get_specific_suricata_log_not_present():
+    # Assuming "alerts.log" is an allowed name but we haven't created it for SAMPLE_ANALYSIS_ID
+    # Need to ensure "alerts.log" is in api_module.ALLOWED_SURICATA_LOGS for this test to be valid
+    if "alerts.log" not in api_module.ALLOWED_SURICATA_LOGS:
+        api_module.ALLOWED_SURICATA_LOGS.append("alerts.log")
+        response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/suricata/alerts.log")
+        assert response.status_code == 404
+        api_module.ALLOWED_SURICATA_LOGS.pop() # cleanup
+    else:
+        # if it's already allowed, just run the test
+        # this assumes the fixture does NOT create 'alerts.log'
+        # create a dummy file that is allowed but not present
+        suricata_dir = os.path.join(TEST_ANALYSIS_RESULTS_DIR, SAMPLE_ANALYSIS_ID, SURICATA_OUTPUT_DIR_NAME)
+        if os.path.exists(os.path.join(suricata_dir, "alerts.log")):
+             os.remove(os.path.join(suricata_dir, "alerts.log")) # ensure it's not there
+        response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/suricata/alerts.log")
+        assert response.status_code == 404
+
+
+def test_get_specific_zeek_log_not_present():
+    # Assuming "notice.log" is an allowed name but not created by fixture
+    if "notice.log" not in api_module.ALLOWED_ZEEK_LOGS:
+        api_module.ALLOWED_ZEEK_LOGS.append("notice.log")
+        response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/zeek/notice.log")
+        assert response.status_code == 404
+        api_module.ALLOWED_ZEEK_LOGS.pop()
+    else:
+        zeek_dir = os.path.join(TEST_ANALYSIS_RESULTS_DIR, SAMPLE_ANALYSIS_ID, ZEEK_OUTPUT_DIR_NAME)
+        if os.path.exists(os.path.join(zeek_dir, "notice.log")):
+             os.remove(os.path.join(zeek_dir, "notice.log"))
+        response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/zeek/notice.log")
+        assert response.status_code == 404
+
+# Final check on root endpoint
+def test_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Welcome to the PCAP Analysis API"}
+
+# Example of testing disallowed file types more explicitly
+def test_get_suricata_log_forbidden_extension():
+    # Create a file like .exe which should never be allowed
+    suricata_dir = os.path.join(TEST_ANALYSIS_RESULTS_DIR, SAMPLE_ANALYSIS_ID, SURICATA_OUTPUT_DIR_NAME)
+    with open(os.path.join(suricata_dir, "somekindof.exe"), "w") as f:
+        f.write("dummy exe")
+
+    response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/suricata/somekindof.exe")
+    assert response.status_code == 400 # Due to not being in ALLOWED_SURICATA_LOGS
+
+def test_get_zeek_log_forbidden_extension():
+    zeek_dir = os.path.join(TEST_ANALYSIS_RESULTS_DIR, SAMPLE_ANALYSIS_ID, ZEEK_OUTPUT_DIR_NAME)
+    with open(os.path.join(zeek_dir, "somekindof.exe"), "w") as f:
+        f.write("dummy exe")
+
+    response = client.get(f"/api/analyses/{SAMPLE_ANALYSIS_ID}/zeek/somekindof.exe")
+    assert response.status_code == 400 # Due to not being in ALLOWED_ZEEK_LOGS


### PR DESCRIPTION
This commit introduces new API endpoints to access detailed results from PCAP analysis, supporting dashboard integration.

Key changes:

- Updated `config/settings.py` with standardized names for output files and directories.
- Enhanced `api.py`:
    - Added `/api/analyses` to list all completed analysis IDs.
    - Added `/api/analyses/{id}/report` for the main Markdown report.
    - Added `/api/analyses/{id}/suricata/{log}` for Suricata logs (eve.json, fast.log, etc.).
    - Added `/api/analyses/{id}/zeek/{log}` for Zeek logs.
    - Added `/api/analyses/{id}/threat_intel` for threat intelligence JSON output.
    - Added `/api/analyses/{id}/anomalies` for anomaly detection JSON output.
    - Included OpenAPI documentation (docstrings and summaries) for all new endpoints.
- Modified `main.py`:
    - The `threat_intel_node` now saves its output to `threat_intelligence.json` within the analysis directory.
    - The `anomaly_detection_node` now saves its output to `anomalies.json` within the analysis directory.
- Added `tests/test_api.py` with a comprehensive suite of unit tests for all new API endpoints, covering success and error cases.
- Created `tests/__init__.py`.

These changes allow external systems (like a dashboard) to retrieve structured data and specific log files generated during the PCAP analysis workflow.